### PR TITLE
fix: release config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,30 +15,20 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
 
-      - name: Lint Commit Message
-        run: |
-          yarn add -D @commitlint/config-conventional
-          echo $(git log -1 --pretty=format:"%s") | yarn commitlint
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Create .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            @nestjs-pact:registry=https://registry.npmjs.org/
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: corepack enable
+        # Required for yarn, when run via act locally
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn install
 
-      # - name: Bootstrap Packages
-      #   run: yarn lerna bootstrap
+      - name: Lint Commit Message
+        run: |
+          echo $(git log -1 --pretty=format:"%s") | yarn commitlint
 
       - name: Build
         run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'yarn'
+
+      - run: corepack enable
+        # Required for yarn, when run via act locally
+
+      - name: Install Dependencies
+        run: yarn install
+          
       - name: Lint Commit Message
-        working-directory: commit-lint
-        run: |
-          yarn init -y
-          yarn add -D @commitlint/config-conventional
-          echo $(git log -1 --pretty=format:"%s") | yarn commitlint
+        run: echo $(git log -1 --pretty=format:"%s") | yarn commitlint
 
       - name: Create .npmrc
         run: |
@@ -28,20 +36,10 @@ jobs:
             FirstName LastName (omer.mroadd@gmail.com, omer.mroadd@gmail.com)=true
             email=omer.mroadd@gmail.com
             always-auth=true
+            access=public
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Setup Node.js 16.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-
-      - name: Install Dependencies
-        run: yarn install
-
-      # - name: Bootstrap Packages
-      #   run: yarn lerna bootstrap
 
       - name: Build
         run: yarn build
@@ -50,11 +48,23 @@ jobs:
         run: yarn test
 
       - name: Release
-        id: changesets
-        uses: changesets/action@v1
+        uses: cycjimmy/semantic-release-action@v3
         with:
-          publish: npm publish
-          commit: "chore: version packages"
+          dry_run: false
+          semantic_version: 16
+          branches: |    
+            [
+              'master', 
+              'next', 
+              {
+                name: 'beta', 
+                prerelease: true
+              }, 
+              {
+                name: 'alpha', 
+                prerelease: true
+              },
+            ]
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
             FirstName LastName (omer.mroadd@gmail.com, omer.mroadd@gmail.com)=true
             email=omer.mroadd@gmail.com
             always-auth=true
-            access=public
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@
 
 ## Table Of Contents
 
+- [Table Of Contents](#table-of-contents)
 - [Installation](#installation)
 - [Example](#example)
 - [About](#about)
 - [Introduction](#introduction)
-- [Contributing](#contributing)
+  - [Consumer](#consumer)
+  - [Provider](#provider)
 - [License](#license)
 - [Acknowledgements](#acknowledgements)
 
@@ -31,7 +33,7 @@
 ## Installation
 
 ```bash
-npm i -D nestjs-pact @pact-foundation/pact
+npm i -D @pact-foundation/nestjs-pact @pact-foundation/pact
 ```
 
 ## Example
@@ -69,7 +71,7 @@ load the `PactConsumerModule` like below:
 
 ```typescript
 import { Module } from '@nestjs/common';
-import { PactConsumerModule } from 'nestjs-pact';
+import { PactConsumerModule } from '@pact-foundation/nestjs-pact';
 
 @Module({
   imports: [
@@ -86,7 +88,7 @@ Yay, now let's create the test file! let's call it `my-test.spec.ts`
 ```typescript
 import { Pact } from '@pact-foundation/pact';
 import { Test } from '@nestjs/testing';
-import { PactFactory } from 'nestjs-pact';
+import { PactFactory } from '@pact-foundation/nestjs-pact';
 import { PactModule } from '@test/pact/pact.module';
 
 describe('Pact', () => {
@@ -132,7 +134,7 @@ Now let's look how we can publish the pacts created from the test file to a Pact
 import { NestFactory } from '@nestjs/core';
 import { Logger, LoggerService } from '@nestjs/common';
 import { Publisher } from '@pact-foundation/pact';
-import { PactModuleProviders } from 'nestjs-pact';
+import { PactModuleProviders } from '@pact-foundation/nestjs-pact';
 import { PactModule } from '@test/pact/pact.module';
 
 (async () => {
@@ -171,7 +173,7 @@ Note: in your `tsconfig.json` file make sure you set `allowJs` to `true` in orde
 
 The usage in the `Provider` service is quite easy; In your `/test` folder (or wherever you put your tests)
 create a simple test module with NestJS `Test.createTestingModule` method and import the `PactProviderModule` module
-from `nestjs-pact`.
+from `@pact-foundation/nestjs-pact`.
 
 You can use `register` or `registerAsync` method, make sure you stick to `PactProviderOptions` interface options. \
 After creating the Nest application from the testing module, pass the app instance to the `verify` method,
@@ -184,7 +186,7 @@ Here is a quick and simple example:
 ```typescript
 import { Test } from '@nestjs/testing';
 import { INestApplication, Logger, LoggerService } from '@nestjs/common';
-import { PactProviderModule, PactVerifierService } from 'nestjs-pact';
+import { PactProviderModule, PactVerifierService } from '@pact-foundation/nestjs-pact';
 import { AppModule } from '@app/app.module';
 
 describe('Pact Verification', () => {

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ## Installation
 
 ```bash
-npm i -D @pact-foundation/nestjs-pact @pact-foundation/pact
+npm i -D nestjs-pact @pact-foundation/pact
 ```
 
 ## Example
@@ -71,7 +71,7 @@ load the `PactConsumerModule` like below:
 
 ```typescript
 import { Module } from '@nestjs/common';
-import { PactConsumerModule } from '@pact-foundation/nestjs-pact';
+import { PactConsumerModule } from 'nestjs-pact';
 
 @Module({
   imports: [
@@ -88,7 +88,7 @@ Yay, now let's create the test file! let's call it `my-test.spec.ts`
 ```typescript
 import { Pact } from '@pact-foundation/pact';
 import { Test } from '@nestjs/testing';
-import { PactFactory } from '@pact-foundation/nestjs-pact';
+import { PactFactory } from 'nestjs-pact';
 import { PactModule } from '@test/pact/pact.module';
 
 describe('Pact', () => {
@@ -134,7 +134,7 @@ Now let's look how we can publish the pacts created from the test file to a Pact
 import { NestFactory } from '@nestjs/core';
 import { Logger, LoggerService } from '@nestjs/common';
 import { Publisher } from '@pact-foundation/pact';
-import { PactModuleProviders } from '@pact-foundation/nestjs-pact';
+import { PactModuleProviders } from 'nestjs-pact';
 import { PactModule } from '@test/pact/pact.module';
 
 (async () => {
@@ -173,7 +173,7 @@ Note: in your `tsconfig.json` file make sure you set `allowJs` to `true` in orde
 
 The usage in the `Provider` service is quite easy; In your `/test` folder (or wherever you put your tests)
 create a simple test module with NestJS `Test.createTestingModule` method and import the `PactProviderModule` module
-from `@pact-foundation/nestjs-pact`.
+from `nestjs-pact`.
 
 You can use `register` or `registerAsync` method, make sure you stick to `PactProviderOptions` interface options. \
 After creating the Nest application from the testing module, pass the app instance to the `verify` method,
@@ -186,7 +186,7 @@ Here is a quick and simple example:
 ```typescript
 import { Test } from '@nestjs/testing';
 import { INestApplication, Logger, LoggerService } from '@nestjs/common';
-import { PactProviderModule, PactVerifierService } from '@pact-foundation/nestjs-pact';
+import { PactProviderModule, PactVerifierService } from 'nestjs-pact';
 import { AppModule } from '@app/app.module';
 
 describe('Pact Verification', () => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pact-foundation/nestjs-pact",
+  "name": "nestjs-pact",
   "version": "2.2.1",
   "license": "MIT",
   "description": "Injectable Pact.js Consumer/Producer for NestJS",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nestjs-pact",
+  "name": "@pact-foundation/nestjs-pact",
   "version": "2.2.1",
   "license": "MIT",
   "description": "Injectable Pact.js Consumer/Producer for NestJS",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Create automated release pipeline for changes to nestjs-pact

## Motivation and Context

the current release pipeline did not have

- a valid NPM_TOKEN for publishing to the current scope `nestjs-pact` - I do not have rights to publish to that, so have used a scoped `@pact-foundation/nestjs-pact` token
- Lerna, which was the commands expected for publishing

## How Has This Been Tested?

E2E and published here

https://www.npmjs.com/package/@pact-foundation/nestjs-pact?activeTab=versions

![Screenshot 2023-01-16 at 19 15 26](https://user-images.githubusercontent.com/19932401/212751589-cc2eeb48-6022-4cb2-8d84-19fcab2eed31.png)

I'd ideally like to delete that version, within 72 hours of creation, so that we can re-use the version number again

https://docs.npmjs.com/policies/unpublish#packages-published-less-than-72-hours-ago

but as its the only version , we won't be able to publish again to it for 24 hours

If you entirely unpublish all versions of a package, you may not publish any new versions of that package until 24 hours have passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

This would actually be a breaking change, as it currently stands as it would break the user imports.

@omermorad you could update the NPM_TOKEN secrets value with an automation token generated under your account, as that will allow us to use this method to publish under the original package name.

That way this change wouldn't have an effect on end-user behaviour but provide us the means to have automated releases, which will support our current active contributors
