### PR TITLE
fix(deps): add nestjs v11 to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "@nestjs/common": "7.x || 8.x || 9.x || 10.x",
-    "@nestjs/core": "7.x || 8.x || 9.x || 10.x",
+    "@nestjs/common": "7.x || 8.x || 9.x || 10.x || 11.x",
+    "@nestjs/core": "7.x || 8.x || 9.x || 10.x || 11.x",
     "@pact-foundation/pact": "10.x || 11.x || 12.x || 13.x || 14.x",
     "@pact-foundation/pact-cli": "15.x || 16.x"
   },


### PR DESCRIPTION
relates to #88

Haven't tested with nest-js v11 but this will allow end users to, and hopefully allow for them to propose any fixes for required support