### PR TITLE
chore(peer-deps): update pact-js to allow 15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "@nestjs/common": "^9.2.1",
     "@nestjs/core": "^9.2.1",
     "@nestjs/testing": "^9.2.1",
-    "@pact-foundation/pact": "^13.1.4",
-    "@pact-foundation/pact-cli": "^16.0.4",
+    "@pact-foundation/pact": "^15.0.0",
+    "@pact-foundation/pact-cli": "^16.0.7",
     "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/git": "^10.0.1",
     "@types/get-port": "^4.2.0",
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@nestjs/common": "7.x || 8.x || 9.x || 10.x || 11.x",
     "@nestjs/core": "7.x || 8.x || 9.x || 10.x || 11.x",
-    "@pact-foundation/pact": "10.x || 11.x || 12.x || 13.x || 14.x",
+    "@pact-foundation/pact": "10.x || 11.x || 12.x || 13.x || 14.x || 15.x",
     "@pact-foundation/pact-cli": "15.x || 16.x"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@nestjs/common": "^9.2.1",
     "@nestjs/core": "^9.2.1",
     "@nestjs/testing": "^9.2.1",
-    "@pact-foundation/pact": "^15.0.0",
+    "@pact-foundation/pact": "^15.0.1",
     "@pact-foundation/pact-cli": "^16.0.7",
     "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/git": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,16 +905,17 @@
     "@pact-foundation/pact-core-linux-x64-musl" "16.0.0"
     "@pact-foundation/pact-core-windows-x64" "16.0.0"
 
-"@pact-foundation/pact@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-15.0.0.tgz#2bdec3f4a8d2b296f72c0692f0247c3c8b32958b"
-  integrity sha512-qZMWz4k6ROxMsPcWnyxNAFi58AhcgiuOaSWMsUKz4q4UF+5W2nK+4PnXIGJPTako0X0zurfxgxcTwCB9QHlSHw==
+"@pact-foundation/pact@^15.0.1":
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-15.0.1.tgz#b05270149d5720186198114b5bf6e333ebba634e"
+  integrity sha512-9pv9mN/grXiXCPmyzQb9YYeyT8aHYO4uRNtfuR4IGLhNSHkHIhiS97ZUsegPruVkWiTcCv9tJahG+1OhL5BrTQ==
   dependencies:
     "@pact-foundation/pact-core" "^16.0.0"
     axios "^1.8.4"
     body-parser "^1.20.3"
     chalk "4.1.2"
     express "^4.21.1"
+    graphql "^16.10.0"
     graphql-tag "^2.9.1"
     http-proxy "^1.18.1"
     https-proxy-agent "^7.0.4"
@@ -4309,6 +4310,11 @@ graphql-tag@^2.9.1:
   resolved "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz"
   dependencies:
     tslib "^2.1.0"
+
+graphql@^16.10.0:
+  version "16.10.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.10.0.tgz#24c01ae0af6b11ea87bf55694429198aaa8e220c"
+  integrity sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==
 
 har-schema@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,39 +803,39 @@
     consola "^2.15.0"
     node-fetch "^2.6.1"
 
-"@pact-foundation/pact-cli-darwin-arm64@16.0.4":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-darwin-arm64/-/pact-cli-darwin-arm64-16.0.4.tgz#2cec316601b65991f0a0903842ab9f5b76a04595"
-  integrity sha512-WWAZn+3HrnItVXqh04e99DgCdiW2T6I4ZRg3MPC5HeOQ3aowspPa1+VSoPMhM7txG0ZkmiQUbBiXPJjebhYLwg==
+"@pact-foundation/pact-cli-darwin-arm64@16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-darwin-arm64/-/pact-cli-darwin-arm64-16.0.7.tgz#b34821daebee451496faff1f0326037ff811c4bc"
+  integrity sha512-n9GbKfeedEaI7HEWxLwBJraWghUKAZoquHpagV2X4/rVfZDVILbCh8oRWj7CJ/mhn7RTVNH2Vf2WRNV49fOH0w==
 
-"@pact-foundation/pact-cli-darwin-x64@16.0.4":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-darwin-x64/-/pact-cli-darwin-x64-16.0.4.tgz#4b241cfe08a40ec23893adeb3c14fcb90113061d"
-  integrity sha512-THSBPlwA3boHUlxMAyv11H6RPXYEiNas2D/PmFlwgWqRjNsLxC52wUCimBPMFiRgAZEuMVbyb4spQI4+UqZe9Q==
+"@pact-foundation/pact-cli-darwin-x64@16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-darwin-x64/-/pact-cli-darwin-x64-16.0.7.tgz#88152dac1d408864a5c6215c8ab13653990ac0f7"
+  integrity sha512-S71H+yJdyW5pGKU9EqM5V7/mp3/JCvUOpc4uOjoG+8r0z6zzlGzbZJicLz5iPOj+1LUFJLXrH4OBK6zMiZm7oA==
 
-"@pact-foundation/pact-cli-linux-arm64@16.0.4":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-linux-arm64/-/pact-cli-linux-arm64-16.0.4.tgz#6b87851dd65d9560a34794975d04c9ce1feeeac2"
-  integrity sha512-e4tLUlUJgK2vJG1OlaVx2oJRnFERdMPryVuvkVnJ9Lbd8RLT07s5i10A92rOUkSVYOM0BV6Ulp7GY0brFg4ZMg==
+"@pact-foundation/pact-cli-linux-arm64@16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-linux-arm64/-/pact-cli-linux-arm64-16.0.7.tgz#e66ceebca2cf4f046477064a26c9157f50f21bba"
+  integrity sha512-VPiNKIGShY11W6/OZlHf5GZHowQfLcsaCKC+lSiQnvDZ52788p5BpHT05AjklMgH0LBn4lJ9NufXjux9WAvtlQ==
 
-"@pact-foundation/pact-cli-linux-x64@16.0.4":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-linux-x64/-/pact-cli-linux-x64-16.0.4.tgz#e679e3e80d0bcd7cfa845236055dae6d23f45b86"
-  integrity sha512-VjEOjStCDR+kCy9WHg8k8nW4zZMqbPaCTKn5xBhgTdG/b1xTc29HZAb2Q/+XHwK8AB3Yi6+BDMeIEp/JBeRy9Q==
+"@pact-foundation/pact-cli-linux-x64@16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-linux-x64/-/pact-cli-linux-x64-16.0.7.tgz#d2ae840b3cb146c34b5c71c726a584951e5d7e2c"
+  integrity sha512-sgHLyKyFigROPZGAzkZGZgUk18sv1kDApYnUpOT5OCf/qmhCJ270KPyUKgZG9HBiVBZe0sa4N3897xp4Urpz/w==
 
-"@pact-foundation/pact-cli-windows-x64@16.0.4":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-windows-x64/-/pact-cli-windows-x64-16.0.4.tgz#1fe4c74692e2277fb3ddfdc95bccf01b82e5aabc"
-  integrity sha512-xvVx/xXYPIjuR1PhK+VxiksnQfmq0h6z4WGYZcS3c6ygSMvvcBZL7ZT5zLr+LEF6EnSnD7eQr2QK7cY6YX5ugg==
+"@pact-foundation/pact-cli-windows-x64@16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli-windows-x64/-/pact-cli-windows-x64-16.0.7.tgz#e9ca1d33c44ea464b21e77059083a205f2b56b73"
+  integrity sha512-kahbIHx3rwIfg6/GUtAQlYXp77QgbWGYa7hkkviuOkmTPfU06KaW2H0KGKGN2u9ntYGpLoGJNfwfYcWC8OodSQ==
 
-"@pact-foundation/pact-cli@^16.0.4":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli/-/pact-cli-16.0.4.tgz#0b900d0472b6b390aceef0fafd73aee112e62942"
-  integrity sha512-qXzJUnXb6XMZyiXwfKgRwUQfpS61uSiLguR2hQWC3m+RrdnzrYug+YBHoACdIlvH6Lj/SQ86/26UJ4Z9V+OYMw==
+"@pact-foundation/pact-cli@^16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-cli/-/pact-cli-16.0.7.tgz#d8e142973ff69ec09021a27a4f4c52ddfa8da7f0"
+  integrity sha512-lm0n7txmeHpPdrvqP2NZD6U85DGpJJWA0V6JqMIFEB+sBG6k7ULeKK7ggqzXKYcgy7b1SUqDaXQIOigF1gbz5w==
   dependencies:
     chalk "4.1.2"
     check-types "11.2.3"
-    cross-spawn "7.0.5"
+    cross-spawn "7.0.6"
     mkdirp "3.0.1"
     needle "^3.3.1"
     pino "^9.5.0"
@@ -844,45 +844,82 @@
     rimraf "4.4.1"
     underscore "1.13.7"
   optionalDependencies:
-    "@pact-foundation/pact-cli-darwin-arm64" "16.0.4"
-    "@pact-foundation/pact-cli-darwin-x64" "16.0.4"
-    "@pact-foundation/pact-cli-linux-arm64" "16.0.4"
-    "@pact-foundation/pact-cli-linux-x64" "16.0.4"
-    "@pact-foundation/pact-cli-windows-x64" "16.0.4"
+    "@pact-foundation/pact-cli-darwin-arm64" "16.0.7"
+    "@pact-foundation/pact-cli-darwin-x64" "16.0.7"
+    "@pact-foundation/pact-cli-linux-arm64" "16.0.7"
+    "@pact-foundation/pact-cli-linux-x64" "16.0.7"
+    "@pact-foundation/pact-cli-windows-x64" "16.0.7"
 
-"@pact-foundation/pact-core@^15.1.0":
-  version "15.2.1"
-  resolved "https://registry.npmjs.org/@pact-foundation/pact-core/-/pact-core-15.2.1.tgz"
-  integrity sha512-IhWwc026bqffjHAVjOfVnDzmhRlr7FBVrLeg/pKjhrcIi0Z/bWahU0u3LEKKctnMkICSH4nAVTYZEg3kUNTxag==
+"@pact-foundation/pact-core-darwin-arm64@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core-darwin-arm64/-/pact-core-darwin-arm64-16.0.0.tgz#c18b91993e680f819f7e571dbc9bc43f6716c835"
+  integrity sha512-cXMBT9o+1Vs/bXJRwa+UNpgBJZ6MvI35IPL1vtiRdd1eclsZEkilRznzKFokcB2fO+oOFsq7LDY4eFGgsfPiEg==
+
+"@pact-foundation/pact-core-darwin-x64@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core-darwin-x64/-/pact-core-darwin-x64-16.0.0.tgz#ac04363acdf9f2f0a1969c962b6ae862d1ae416a"
+  integrity sha512-in9VZsuvQnqHHD+hxcwERYPESPHM6ZapJx0ptZKXPIOsSIfAlNEeXWI9a6cqdHE87oEE+ypyMDV9HcARLbCxGA==
+
+"@pact-foundation/pact-core-linux-arm64-glibc@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core-linux-arm64-glibc/-/pact-core-linux-arm64-glibc-16.0.0.tgz#c8500843cbb6bc82233007c563764fde01ad0db8"
+  integrity sha512-EbfSfnveyx1Fo73Cyx8IAor8Af6j6hxspikJTKNbencpsrEeXgOCBGFvnwTHR+xuvn88oBmRo0MtGJwsIT1S1A==
+
+"@pact-foundation/pact-core-linux-arm64-musl@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core-linux-arm64-musl/-/pact-core-linux-arm64-musl-16.0.0.tgz#34390daa19fee8b9b31e2cdb7a49e7cc42c7e96f"
+  integrity sha512-hQW06EYz3leTTfNZx6126JsghC8Ilqg8FToY0mLUBZ/Y9RKM9msOR7bJi05u8nHA7g2JBFyIwNllkq5aqELeIg==
+
+"@pact-foundation/pact-core-linux-x64-glibc@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core-linux-x64-glibc/-/pact-core-linux-x64-glibc-16.0.0.tgz#8eba976c19566d980459b75439f318bef58ee454"
+  integrity sha512-DqwIoM15YXol6Xc3YoCrWazEF9u/Z97zU2an83ceroRXc1VWEjf+ssd/LRT11J8OPhC2e11RDyRp+qgGWIES1Q==
+
+"@pact-foundation/pact-core-linux-x64-musl@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core-linux-x64-musl/-/pact-core-linux-x64-musl-16.0.0.tgz#e8dd3f14e7aeb6503d374cfd03d3dc8108eb13fc"
+  integrity sha512-C9b+lhYrwpn96USpeWNNZrbOoaMKo7/JqFoL81V9QQFmUawZOZNhp1i5HbznM35Apk2QdLM73P2DESUryVJ4ng==
+
+"@pact-foundation/pact-core-windows-x64@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core-windows-x64/-/pact-core-windows-x64-16.0.0.tgz#6215c94967f553ac631fb1e719251f13e3562bcc"
+  integrity sha512-/6d0bjouofuSCWM2wauAf7+tD2AG+y5X0duchkj0vpjBdYG7tbgEB322QcyTWBi7na4plEdLSdIMnfZs6faEqA==
+
+"@pact-foundation/pact-core@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact-core/-/pact-core-16.0.0.tgz#7544db4e7fb1ef0399bf7477017a59029ddba434"
+  integrity sha512-Zdo/JIsReDrJLg0tCN0IinTmMi4tU+gmKPNc70J0wY0j/zMuL4xdpqotKhIDChf9yK4sEr2K24lKEZ9yQN2eWw==
   dependencies:
-    check-types "7.3.0"
+    check-types "7.4.0"
+    detect-libc "^2.0.3"
     node-gyp-build "^4.6.0"
     pino "^8.7.0"
     pino-pretty "^9.1.1"
-    underscore "1.12.1"
+    underscore "1.13.7"
+  optionalDependencies:
+    "@pact-foundation/pact-core-darwin-arm64" "16.0.0"
+    "@pact-foundation/pact-core-darwin-x64" "16.0.0"
+    "@pact-foundation/pact-core-linux-arm64-glibc" "16.0.0"
+    "@pact-foundation/pact-core-linux-arm64-musl" "16.0.0"
+    "@pact-foundation/pact-core-linux-x64-glibc" "16.0.0"
+    "@pact-foundation/pact-core-linux-x64-musl" "16.0.0"
+    "@pact-foundation/pact-core-windows-x64" "16.0.0"
 
-"@pact-foundation/pact@^13.1.4":
-  version "13.1.4"
-  resolved "https://registry.npmjs.org/@pact-foundation/pact/-/pact-13.1.4.tgz"
-  integrity sha512-IMATSPETNNA+EybSH6r89xo5NLjrzr7RR1e5FXy4DhNbdzAUlG+BTgZUy40oD1GIScugVu/Di0VHM3LPaTve8A==
+"@pact-foundation/pact@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@pact-foundation/pact/-/pact-15.0.0.tgz#2bdec3f4a8d2b296f72c0692f0247c3c8b32958b"
+  integrity sha512-qZMWz4k6ROxMsPcWnyxNAFi58AhcgiuOaSWMsUKz4q4UF+5W2nK+4PnXIGJPTako0X0zurfxgxcTwCB9QHlSHw==
   dependencies:
-    "@pact-foundation/pact-core" "^15.1.0"
-    "@types/express" "^4.17.11"
-    axios "^1.7.4"
+    "@pact-foundation/pact-core" "^16.0.0"
+    axios "^1.8.4"
     body-parser "^1.20.3"
-    cli-color "^2.0.1"
-    express "^4.21.0"
-    graphql "^14.0.0"
+    chalk "4.1.2"
+    express "^4.21.1"
     graphql-tag "^2.9.1"
     http-proxy "^1.18.1"
     https-proxy-agent "^7.0.4"
     js-base64 "^3.6.1"
     lodash "^4.17.21"
-    lodash.isfunction "3.0.8"
-    lodash.isnil "4.0.0"
-    lodash.isundefined "3.0.1"
-    lodash.omit "^4.5.0"
-    pkginfo "^0.4.1"
     ramda "^0.30.0"
     randexp "^0.5.3"
 
@@ -998,36 +1035,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/body-parser@*":
-  version "1.19.2"
-  resolved "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz"
-  dependencies:
-    "@types/connect" "*"
-    "@types/node" "*"
-
-"@types/connect@*":
-  version "3.4.35"
-  resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz"
-  dependencies:
-    "@types/node" "*"
-
-"@types/express-serve-static-core@^4.17.18":
-  version "4.17.31"
-  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz"
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-
-"@types/express@^4.17.11":
-  version "4.17.14"
-  resolved "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz"
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.18"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
-
 "@types/get-port@^4.2.0":
   version "4.2.0"
   resolved "https://registry.npmjs.org/@types/get-port/-/get-port-4.2.0.tgz"
@@ -1071,10 +1078,6 @@
   version "0.0.29"
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
 
-"@types/mime@*":
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz"
-
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz"
@@ -1100,14 +1103,6 @@
   version "2.7.1"
   resolved "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz"
 
-"@types/qs@*":
-  version "6.9.7"
-  resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz"
-
-"@types/range-parser@*":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz"
-
 "@types/retry@0.12.0":
   version "0.12.0"
   resolved "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz"
@@ -1116,13 +1111,6 @@
   version "7.5.8"
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
-
-"@types/serve-static@*":
-  version "1.15.0"
-  resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz"
-  dependencies:
-    "@types/mime" "*"
-    "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -1611,10 +1599,10 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
 
-axios@^1.7.4:
-  version "1.7.7"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz"
-  integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==
+axios@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
+  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -2442,10 +2430,10 @@ check-types@11.2.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.2.3.tgz#1ffdf68faae4e941fce252840b1787b8edc93b71"
   integrity sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg==
 
-check-types@7.3.0:
-  version "7.3.0"
-  resolved "https://registry.npmjs.org/check-types/-/check-types-7.3.0.tgz"
-  integrity sha512-bzDMlwEIZFtyK70RHwQhMCvXpPyJZgOCCKlvH9oAJz4quUQse8ZynYE5RQzKpY7b5PoL6G+jQMcZzUPD4p6tFg==
+check-types@7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.4.0.tgz#0378ec1b9616ec71f774931a3c6516fad8c152f4"
+  integrity sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==
 
 chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
   version "1.1.4"
@@ -2484,16 +2472,6 @@ cli-boxes@^1.0.0:
 cli-boxes@^2.2.0:
   version "2.2.1"
   resolved "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz"
-
-cli-color@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz"
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.61"
-    es6-iterator "^2.0.3"
-    memoizee "^0.4.15"
-    timers-ext "^0.1.7"
 
 cli-columns@^3.1.2:
   version "3.1.2"
@@ -2820,10 +2798,10 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
 
-cross-spawn@7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.5.tgz#910aac880ff5243da96b728bc6521a5f6c2f2f82"
-  integrity sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==
+cross-spawn@7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -2875,13 +2853,6 @@ cz-conventional-changelog@3.3.0, cz-conventional-changelog@^3.3.0:
     word-wrap "^1.0.3"
   optionalDependencies:
     "@commitlint/load" ">6.1.1"
-
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/d/-/d-1.0.1.tgz"
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
 
 dargs@^7.0.0:
   version "7.0.0"
@@ -3065,6 +3036,11 @@ detect-indent@^4.0.0:
 detect-indent@~5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz"
+
+detect-libc@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700"
+  integrity sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -3385,23 +3361,6 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@^0.10.61, es5-ext@^0.10.62, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
-  version "0.10.64"
-  resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz"
-  dependencies:
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.3"
-    esniff "^2.0.1"
-    next-tick "^1.1.0"
-
-es6-iterator@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
 es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz"
@@ -3411,22 +3370,6 @@ es6-promisify@^5.0.0:
   resolved "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz"
   dependencies:
     es6-promise "^4.0.3"
-
-es6-symbol@^3.1.1, es6-symbol@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz"
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
-es6-weak-map@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.1"
 
 escalade@^3.1.1:
   version "3.2.0"
@@ -3585,15 +3528,6 @@ eslint@8.56.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-esniff@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz"
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.62"
-    event-emitter "^0.3.5"
-    type "^2.7.2"
-
 espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
   resolved "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz"
@@ -3635,13 +3569,6 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
-
-event-emitter@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
 
 event-target-shim@^5.0.0:
   version "5.0.1"
@@ -3729,10 +3656,10 @@ expect@^29.0.0, expect@^29.3.1:
     jest-message-util "^29.3.1"
     jest-util "^29.3.1"
 
-express@^4.21.0:
-  version "4.21.1"
-  resolved "https://registry.npmjs.org/express/-/express-4.21.1.tgz"
-  integrity sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==
+express@^4.21.1:
+  version "4.21.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"
+  integrity sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
@@ -3753,7 +3680,7 @@ express@^4.21.0:
     methods "~1.1.2"
     on-finished "2.4.1"
     parseurl "~1.3.3"
-    path-to-regexp "0.1.10"
+    path-to-regexp "0.1.12"
     proxy-addr "~2.0.7"
     qs "6.13.0"
     range-parser "~1.2.1"
@@ -3765,12 +3692,6 @@ express@^4.21.0:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
-
-ext@^1.1.2:
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz"
-  dependencies:
-    type "^2.7.2"
 
 extend@~3.0.2:
   version "3.0.2"
@@ -4389,12 +4310,6 @@ graphql-tag@^2.9.1:
   dependencies:
     tslib "^2.1.0"
 
-graphql@^14.0.0:
-  version "14.7.0"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz"
-  dependencies:
-    iterall "^1.2.2"
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
@@ -4948,10 +4863,6 @@ is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
 
-is-promise@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz"
-
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
@@ -5112,10 +5023,6 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-iterall@^1.2.2:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz"
 
 iterare@1.2.1:
   version "1.2.1"
@@ -5849,25 +5756,13 @@ lodash.clonedeep@^4.5.0, lodash.clonedeep@~4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
 
-lodash.isfunction@3.0.8:
-  version "3.0.8"
-  resolved "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz"
-
 lodash.isfunction@^3.0.9:
   version "3.0.9"
   resolved "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz"
 
-lodash.isnil@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz"
-
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
-
-lodash.isundefined@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz"
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
@@ -5888,10 +5783,6 @@ lodash.merge@^4.6.2:
 lodash.mergewith@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz"
-
-lodash.omit@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz"
 
 lodash.snakecase@^4.1.1:
   version "4.1.1"
@@ -5987,12 +5878,6 @@ lru-cache@^6.0.0:
   version "10.0.1"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz"
 
-lru-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
-  dependencies:
-    es5-ext "~0.10.2"
-
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz"
@@ -6048,19 +5933,6 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
-
-memoizee@^0.4.15:
-  version "0.4.15"
-  resolved "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz"
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.53"
-    es6-weak-map "^2.0.3"
-    event-emitter "^0.3.5"
-    is-promise "^2.2.2"
-    lru-queue "^0.1.0"
-    next-tick "^1.1.0"
-    timers-ext "^0.1.7"
 
 meow@^8.0.0:
   version "8.1.2"
@@ -6287,10 +6159,6 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
-next-tick@1, next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -6992,10 +6860,10 @@ path-scurry@^1.6.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz"
-  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
+path-to-regexp@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
+  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
 path-to-regexp@3.2.0:
   version "3.2.0"
@@ -7137,10 +7005,6 @@ pkg-dir@^4.2.0:
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz"
   dependencies:
     find-up "^4.0.0"
-
-pkginfo@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz"
 
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
@@ -8559,13 +8423,6 @@ timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz"
 
-timers-ext@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz"
-  dependencies:
-    es5-ext "~0.10.46"
-    next-tick "1"
-
 tiny-glob@^0.2.9:
   version "0.2.9"
   resolved "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz"
@@ -8774,14 +8631,6 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/type/-/type-1.2.0.tgz"
-
-type@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.npmjs.org/type/-/type-2.7.2.tgz"
-
 typed-array-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz"
@@ -8889,11 +8738,6 @@ unbox-primitive@^1.0.2:
 underscore.string@~2.2.0rc:
   version "2.2.1"
   resolved "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
-
-underscore@1.12.1:
-  version "1.12.1"
-  resolved "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz"
-  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
 underscore@1.13.7:
   version "1.13.7"


### PR DESCRIPTION
15.0.0 was published as a major instead of a patch due to an issue with the release process.

No breaking changes, see https://github.com/pact-foundation/pact-js/issues/1372#issuecomment-2749010795 for background