### PR TITLE
chore(ci): force ! to trigger breaking change

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,8 +3,18 @@
   "repositoryUrl": "https://github.com/omermorad/nestjs-pact.git",
   "debug": "true",
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     "@semantic-release/npm",
     "@semantic-release/github",
     [


### PR DESCRIPTION
Semantic release does not pick up commit titles with `!` in, which is used to denote breaking changes.

Update config to use `conventionalcommits` present, in order to trigger release of #96 